### PR TITLE
Change requirements to stable pyinstaller

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/pyinstaller/pyinstaller.git
+pyinstaller


### PR DESCRIPTION
GTK4 support was added in 5.2 so there's no need to use the development version