### PR TITLE
Update windows bootstrap script

### DIFF
--- a/windows/bootstrap.sh
+++ b/windows/bootstrap.sh
@@ -2,6 +2,6 @@
 
 # This script is meant to be run through MinGW
 
-pacman -S --noconfirm mingw-w64-$(uname -m)-gtk3 mingw-w64-$(uname -m)-python-pip mingw-w64-$(uname -m)-python3-gobject mingw-w64-$(uname -m)-nsis mingw-w64-$(uname -m)-nsis-nsisunz mingw-w64-$(uname -m)-gcc zip unzip
+pacman -S --noconfirm mingw-w64-$(uname -m)-gtk3 mingw-w64-$(uname -m)-python-pip mingw-w64-$(uname -m)-python3-gobject mingw-w64-$(uname -m)-nsis mingw-w64-$(uname -m)-nsis-nsisunz zip unzip
 
 echo "Done"


### PR DESCRIPTION
C compiler is no longer needed since we don't build pyinstaller from scratch anymore