### PR TITLE
fix: Update bootstrap.sh

### DIFF
--- a/macos/bootstrap.sh
+++ b/macos/bootstrap.sh
@@ -1,1 +1,1 @@
-brew install pygobject3 gtk4 adwaita-icon-theme libadwaita
+PIP_BREAK_SYSTEM_PACKAGES=1 brew install pygobject3 gtk4 adwaita-icon-theme libadwaita


### PR DESCRIPTION
The macOS 14 runner is having trouble installing libadwaita. We add an environment variable to see if this fixes the matter.