### PR TITLE
ci: Fix macOS x86 workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Install dependencies
         run: |
           ./macos/bootstrap.sh
+          python3 -m pip install pycairo
+          python3 -m pip install PyGObject
       - name: Set up environment
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}


### PR DESCRIPTION
For reasons I fail to understand, we need to install pycairo and PyGObject via pip for just intel macOS