### PR TITLE
ci: Remove set up python step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,10 +133,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
       - name: Set up MSYS2
         uses: msys2/setup-msys2@v2
         with:


### PR DESCRIPTION
The set up python step in the release CI just causes unpredictable problems. This commit removes the step from the build process for every runner.