### PR TITLE
chore: Update macOS Intel runner

### DIFF
--- a/.github/workflows/build-macos-intel.yml
+++ b/.github/workflows/build-macos-intel.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-macos-intel:
     name: Build for macOS Intel
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Update the macOS Intel runner from `macos-13` to `macos-15-intel`